### PR TITLE
Implement F8995 rather than 8995a for lower income bracket, with business income

### DIFF
--- a/2023/f1040.py
+++ b/2023/f1040.py
@@ -132,7 +132,7 @@ class F1040(Form):
             f['12'] = std
 
         if f['11']-f['12'] < f.BRACKET_LIMITS[inputs['status']][3]:
-            f8995 = f.addForm(F8995(inputs, f, sd, sse))
+            f8995 = f.addForm(F8995(inputs, f, sd))
             if f8995.mustFile():
                 f['13'] = f8995['15']
         else:
@@ -154,6 +154,7 @@ class F1040(Form):
         # Compute line s3_1 now because it's needed by AMT
         f.comment['s3_1'] = 'Foreign Tax Paid'
         foreign_tax = inputs.get('foreign_tax', 0)
+        assert(foreign_tax < 300 or (foreign_tax < 600 and inputs['status'] == FilingStatus.JOINT))
         if foreign_tax:
             f['s3_1'] = foreign_tax
 

--- a/2023/f8960.py
+++ b/2023/f8960.py
@@ -9,7 +9,7 @@ class F8960(Form):
         f['2'] = f1040.get('3b')
         # TODO: annuities
         f['4a'] = f1040.rowsum(['s1_3', 's1_5'])
-        f['4b'] = -f1040['s1_3']
+        f['4b'] = -f1040['s1_3'] or None
         f['4c'] = f.rowsum(['4a', '4b'])
         f['5a'] = f1040.rowsum(['7', 's1_4'])
         f['5d'] = f.rowsum(['5a', '5b', '5c'])

--- a/2023/f8995.py
+++ b/2023/f8995.py
@@ -2,7 +2,7 @@ from form import Form, FilingStatus
 
 class F8995(Form):
     """Form 8995, Qualified Business Income Deduction Simplified Computation"""
-    def __init__(f, inputs, f1040, sched_d, sse):
+    def __init__(f, inputs, f1040, sched_d):
         super(F8995, f).__init__(inputs)
 
         f['2'] = f1040['s1_3'] - (f1040.rowsum(['s1_1[567]']) or 0)
@@ -14,7 +14,10 @@ class F8995(Form):
         f['9'] = f['8'] * 0.2
         f['10'] = f['5'] + f['9']
         f['11'] = f1040['11'] - f1040['12']
-        f['12'] = f1040['7'] + f1040['3a']
+        if sched_d.mustFile():
+            f['12'] = f1040['3a'] + max(0, min(sched_d['15'], sched_d['16']))
+        else:
+            f['12'] = f1040['3a'] + f1040['7']
         f['13'] = max(0,f['11'] - f['12'])
         f['14'] = f['13'] * 0.20
         f['15'] = min(f['10'], f['14'])

--- a/2024/f1040.py
+++ b/2024/f1040.py
@@ -142,7 +142,7 @@ class F1040(Form):
             f['12'] = std
 
         if f['11']-f['12'] < f.BRACKET_LIMITS[inputs['status']][3]:
-            f8995 = f.addForm(F8995(inputs, f, sd, sse))
+            f8995 = f.addForm(F8995(inputs, f, sd))
             if f8995.mustFile():
                 f['13'] = f8995['15']
         else:

--- a/2024/f8960.py
+++ b/2024/f8960.py
@@ -9,7 +9,7 @@ class F8960(Form):
         f['2'] = f1040.get('3b')
         # TODO: annuities
         f['4a'] = f1040.rowsum(['s1_3', 's1_5'])
-        f['4b'] = -f1040['s1_3']
+        f['4b'] = -f1040['s1_3'] or None
         f['4c'] = f.rowsum(['4a', '4b'])
         f['5a'] = f1040.rowsum(['7', 's1_4'])
         f['5d'] = f.rowsum(['5a', '5b', '5c'])

--- a/2024/f8995.py
+++ b/2024/f8995.py
@@ -2,7 +2,7 @@ from form import Form, FilingStatus
 
 class F8995(Form):
     """Form 8995, Qualified Business Income Deduction Simplified Computation"""
-    def __init__(f, inputs, f1040, sched_d, sse):
+    def __init__(f, inputs, f1040, sched_d):
         super(F8995, f).__init__(inputs)
 
         f['2'] = f1040['s1_3'] - (f1040.rowsum(['s1_1[567]']) or 0)
@@ -14,7 +14,10 @@ class F8995(Form):
         f['9'] = f['8'] * 0.2
         f['10'] = f['5'] + f['9']
         f['11'] = f1040['11'] - f1040['12']
-        f['12'] = f1040['7'] + f1040['3a']
+        if sched_d.mustFile():
+            f['12'] = f1040['3a'] + max(0, min(sched_d['15'], sched_d['16']))
+        else:
+            f['12'] = f1040['3a'] + f1040['7']
         f['13'] = max(0,f['11'] - f['12'])
         f['14'] = f['13'] * 0.20
         f['15'] = min(f['10'], f['14'])


### PR DESCRIPTION
Implements F8995 rather than 8995a, with business income, for 2023 and 2024. Please have a look to see if you agree with my changes. I have done them a long time ago, and I have not reviewed them as carefully as I should. Numbers match my online tax preparer.

This PR does not fix F1116, which requires separating net capital gains into gains and losses, and similarly for business income/expenses.