### PR TITLE
Add additional inputs for QBI and nonpassive businesses.

### DIFF
--- a/2024/f8960.py
+++ b/2024/f8960.py
@@ -9,7 +9,7 @@ class F8960(Form):
         f['2'] = f1040.get('3b')
         # TODO: annuities
         f['4a'] = f1040.rowsum(['s1_3', 's1_5'])
-        f['4b'] = -f1040['s1_3'] or None
+        f['4b'] = -inputs.get('nonpassive_business_net_income', f1040['s1_3']) or None
         f['4c'] = f.rowsum(['4a', '4b'])
         f['5a'] = f1040.rowsum(['7', 's1_4'])
         f['5d'] = f.rowsum(['5a', '5b', '5c'])

--- a/2024/f8995.py
+++ b/2024/f8995.py
@@ -5,7 +5,8 @@ class F8995(Form):
     def __init__(f, inputs, f1040, sched_d):
         super(F8995, f).__init__(inputs)
 
-        f['2'] = f1040['s1_3'] - (f1040.rowsum(['s1_1[567]']) or 0)
+        f['2'] = f1040['s1_3'] - (f1040.rowsum(['s1_1[567]']) or 0) \
+                   + inputs.get('additional_qbi', 0)
         f['4'] = max(0, f['2'] + f['3'])
         f['5'] = f['4'] * 0.20
         f['6'] = inputs.get('section_199A_dividends')


### PR DESCRIPTION
Add additional inputs `nonpassive_business_net_income` and `additional_qbi` to allow adjustments of the amounts excluded from NIIT and added to QBI beyond the default Schedule C amounts.